### PR TITLE
Add import mapping dialog with reusable templates

### DIFF
--- a/price_compare/gui.py
+++ b/price_compare/gui.py
@@ -5,14 +5,15 @@ from __future__ import annotations
 import tkinter as tk
 from pathlib import Path
 from tkinter import filedialog, messagebox, simpledialog, ttk
-from typing import Dict, List, Sequence
+from typing import Dict, List, Optional, Sequence
 
 from .comparator import PriceComparator
-from .io import PriceListExporter, PriceListImporter
+from .io import MissingRequiredColumnsError, PriceListExporter, PriceListImporter
 from .models import PriceList, Product
 from .repository import PriceListRepository
 from .search import ProductSearch
 from .tagging import Tagger
+from .templates import ImportTemplate, ImportTemplateStore
 
 
 def _format_price(product: Product) -> str:
@@ -36,6 +37,7 @@ class PriceCompareApp(tk.Tk):
         self.repository = PriceListRepository(data_dir=data_dir)
         self.importer = PriceListImporter()
         self.exporter = PriceListExporter()
+        self.template_store = ImportTemplateStore(data_dir=data_dir)
         self.tagger = Tagger.from_json(tags_config) if tags_config else Tagger()
         self._tags_config_path: str | None = str(tags_config) if tags_config else None
 
@@ -362,12 +364,68 @@ class PriceCompareApp(tk.Tk):
             return
 
         try:
-            price_list = self.importer.load(path, supplier=supplier)
-            self.tagger.apply(price_list.products)
-            self.repository.save(price_list)
+            headers, preview_rows = self.importer.peek(path, limit=15)
+        except Exception as exc:
+            messagebox.showerror(
+                "Помилка імпорту",
+                f"Не вдалося проаналізувати файл: {exc}",
+            )
+            return
+
+        template = self.template_store.get_template(supplier)
+        available_templates = self.template_store.list_templates()
+
+        suggested_mapping = self.importer.suggest_mapping(
+            headers,
+            column_mapping=template.column_mapping if template else None,
+        )
+        initial_mapping = dict(suggested_mapping)
+        if template:
+            for field, column in template.column_mapping.items():
+                if column in headers:
+                    initial_mapping[field] = column
+
+        dialog = ImportSettingsDialog(
+            self,
+            path=path,
+            supplier=supplier,
+            headers=headers,
+            preview_rows=preview_rows,
+            required_fields=sorted(self.importer.required_fields),
+            optional_fields=list(self.importer.optional_fields),
+            initial_mapping=initial_mapping,
+            templates=available_templates,
+            current_template=template,
+        )
+        self.wait_window(dialog)
+
+        if not dialog.result:
+            return
+
+        column_mapping = dialog.result["column_mapping"]
+        save_template = dialog.result["save_template"]
+
+        try:
+            price_list = self.importer.load(
+                path, supplier=supplier, column_mapping=column_mapping
+            )
+        except MissingRequiredColumnsError as exc:
+            messagebox.showerror(
+                "Помилка імпорту",
+                "Не вдалося знайти обов'язкові колонки: {}.\nДоступні заголовки: {}.".format(
+                    ", ".join(exc.missing), ", ".join(exc.headers)
+                ),
+            )
+            return
         except Exception as exc:
             messagebox.showerror("Помилка імпорту", f"Не вдалося імпортувати прайс: {exc}")
             return
+
+        self.tagger.apply(price_list.products)
+        self.repository.save(price_list)
+
+        if save_template:
+            self.template_store.save_template(supplier, column_mapping, headers)
 
         messagebox.showinfo("Готово", f"Імпортовано {len(price_list.products)} позицій.")
         self.refresh_data()
@@ -611,6 +669,257 @@ class PriceCompareApp(tk.Tk):
             return
 
         messagebox.showinfo("Готово", "Найкращі пропозиції експортовано.")
+
+
+class ImportSettingsDialog(tk.Toplevel):
+    """Dialog window for configuring import column mapping."""
+
+    def __init__(
+        self,
+        master: tk.Misc,
+        *,
+        path: str,
+        supplier: str,
+        headers: Sequence[str],
+        preview_rows: Sequence[Dict[str, str]],
+        required_fields: Sequence[str],
+        optional_fields: Sequence[str],
+        initial_mapping: Dict[str, str],
+        templates: Sequence[ImportTemplate],
+        current_template: Optional[ImportTemplate],
+    ) -> None:
+        super().__init__(master)
+        self.title("Налаштування імпорту")
+        self.resizable(True, True)
+        self.transient(master)
+        self.grab_set()
+
+        self.headers = list(dict.fromkeys(headers))
+        self.preview_rows = list(preview_rows)
+        self.required_fields = list(required_fields)
+        self.optional_fields = list(optional_fields)
+        self.initial_mapping = dict(initial_mapping)
+        self.templates = list(templates)
+        self.current_template = current_template
+        self.result: Optional[Dict[str, object]] = None
+
+        self.column_vars: Dict[str, tk.StringVar] = {}
+        for field in self.required_fields + self.optional_fields:
+            self.column_vars[field] = tk.StringVar(value=self.initial_mapping.get(field, ""))
+
+        self.save_template_var = tk.BooleanVar(value=True)
+        self.template_var = tk.StringVar()
+
+        container = ttk.Frame(self, padding=12)
+        container.pack(fill=tk.BOTH, expand=True)
+
+        info_frame = ttk.Frame(container)
+        info_frame.pack(fill=tk.X, pady=(0, 8))
+
+        ttk.Label(info_frame, text="Файл:").grid(row=0, column=0, sticky=tk.W)
+        ttk.Label(info_frame, text=path, font=("TkDefaultFont", 9, "bold")).grid(
+            row=0, column=1, sticky=tk.W, padx=(4, 0)
+        )
+        ttk.Label(info_frame, text="Постачальник:").grid(row=1, column=0, sticky=tk.W, pady=(4, 0))
+        ttk.Label(info_frame, text=supplier).grid(row=1, column=1, sticky=tk.W, padx=(4, 0), pady=(4, 0))
+
+        template_names = ["Автовизначення"]
+        templates_by_name: Dict[str, ImportTemplate] = {}
+        for template in self.templates:
+            name = template.supplier
+            if name in templates_by_name:
+                continue
+            templates_by_name[name] = template
+            template_names.append(name)
+        self.templates_by_name = templates_by_name
+
+        if template_names[1:]:
+            template_frame = ttk.Frame(container)
+            template_frame.pack(fill=tk.X, pady=(0, 12))
+            ttk.Label(template_frame, text="Шаблон:").pack(side=tk.LEFT)
+            template_combo = ttk.Combobox(
+                template_frame,
+                state="readonly",
+                values=template_names,
+                textvariable=self.template_var,
+                width=40,
+            )
+            template_combo.pack(side=tk.LEFT, padx=(6, 0))
+            template_combo.bind("<<ComboboxSelected>>", self._on_template_selected)
+            ttk.Button(
+                template_frame,
+                text="Скинути",
+                command=self._use_initial_mapping,
+            ).pack(side=tk.LEFT, padx=(6, 0))
+        else:
+            self.template_var.set("Автовизначення")
+
+        mapping_frame = ttk.LabelFrame(container, text="Відповідність колонок")
+        mapping_frame.pack(fill=tk.X, pady=(0, 12))
+        mapping_frame.columnconfigure(1, weight=1)
+
+        combobox_values = [""] + self.headers
+        for row_index, field in enumerate(self.required_fields + self.optional_fields):
+            is_required = field in self.required_fields
+            label_text = field.upper() if field in {"sku", "name", "price"} else field
+            if is_required:
+                label_text = f"{label_text} *"
+            ttk.Label(mapping_frame, text=label_text).grid(
+                row=row_index, column=0, sticky=tk.W, padx=(6, 4), pady=4
+            )
+
+            combo = ttk.Combobox(
+                mapping_frame,
+                values=combobox_values,
+                textvariable=self.column_vars[field],
+                state="readonly",
+            )
+            combo.grid(row=row_index, column=1, sticky=tk.EW, padx=(0, 6), pady=4)
+
+        save_template_check = ttk.Checkbutton(
+            mapping_frame,
+            text="Зберегти як шаблон для постачальника",
+            variable=self.save_template_var,
+        )
+        save_template_check.grid(
+            row=len(self.required_fields + self.optional_fields),
+            column=0,
+            columnspan=2,
+            sticky=tk.W,
+            padx=6,
+            pady=(4, 0),
+        )
+
+        preview_frame = ttk.LabelFrame(container, text="Попередній перегляд")
+        preview_frame.pack(fill=tk.BOTH, expand=True)
+
+        if self.headers:
+            tree = ttk.Treeview(
+                preview_frame,
+                columns=self.headers,
+                show="headings",
+                height=8,
+            )
+            tree.grid(row=0, column=0, sticky="nsew")
+            preview_frame.columnconfigure(0, weight=1)
+            preview_frame.rowconfigure(0, weight=1)
+
+            y_scroll = ttk.Scrollbar(preview_frame, orient=tk.VERTICAL, command=tree.yview)
+            y_scroll.grid(row=0, column=1, sticky="ns")
+            x_scroll = ttk.Scrollbar(preview_frame, orient=tk.HORIZONTAL, command=tree.xview)
+            x_scroll.grid(row=1, column=0, sticky="ew")
+            tree.configure(yscrollcommand=y_scroll.set, xscrollcommand=x_scroll.set)
+
+            for header in self.headers:
+                tree.heading(header, text=header)
+                tree.column(header, width=160, anchor=tk.W)
+
+            for row in self.preview_rows:
+                tree.insert(
+                    "",
+                    tk.END,
+                    values=[row.get(header, "") for header in self.headers],
+                )
+        else:
+            ttk.Label(
+                preview_frame,
+                text="Не вдалося визначити заголовки. Файл може бути порожнім.",
+            ).pack(padx=12, pady=12, anchor=tk.W)
+
+        buttons = ttk.Frame(container)
+        buttons.pack(fill=tk.X, pady=(12, 0))
+        buttons.columnconfigure(0, weight=1)
+
+        ttk.Button(buttons, text="Скасувати", command=self._on_cancel).grid(
+            row=0, column=1, padx=(0, 8)
+        )
+        ttk.Button(buttons, text="Імпортувати", command=self._on_ok).grid(row=0, column=2)
+
+        self.bind("<Return>", lambda _event: self._on_ok())
+        self.bind("<Escape>", lambda _event: self._on_cancel())
+
+        if current_template and current_template.supplier in self.templates_by_name:
+            self.template_var.set(current_template.supplier)
+            self._apply_mapping(current_template.column_mapping)
+        else:
+            self.template_var.set("Автовизначення")
+
+    def _use_initial_mapping(self) -> None:
+        self.template_var.set("Автовизначення")
+        self._apply_mapping(self.initial_mapping)
+
+    def _apply_mapping(self, mapping: Dict[str, str]) -> None:
+        for field, var in self.column_vars.items():
+            column = mapping.get(field, "")
+            if column not in self.headers:
+                column = ""
+            var.set(column)
+
+    def _on_template_selected(self, _event: object) -> None:
+        name = self.template_var.get()
+        if name == "Автовизначення":
+            self._apply_mapping(self.initial_mapping)
+            return
+        template = self.templates_by_name.get(name)
+        if template:
+            self._apply_mapping(template.column_mapping)
+
+    def _on_cancel(self) -> None:
+        self.result = None
+        self.destroy()
+
+    def _on_ok(self) -> None:
+        mapping: Dict[str, str] = {}
+        used_columns: set[str] = set()
+
+        for field, var in self.column_vars.items():
+            value = var.get().strip()
+            if not value:
+                if field in self.required_fields:
+                    messagebox.showerror(
+                        "Налаштування імпорту",
+                        "Необхідно обрати колонку для поля '{}'.".format(field),
+                        parent=self,
+                    )
+                    return
+                continue
+
+            if value not in self.headers:
+                messagebox.showerror(
+                    "Налаштування імпорту",
+                    "Колонку '{}' не знайдено у файлі.".format(value),
+                    parent=self,
+                )
+                return
+
+            if field in self.required_fields and value in used_columns:
+                messagebox.showerror(
+                    "Налаштування імпорту",
+                    "Колонка '{}' вже використовується для іншого обов'язкового поля.".format(
+                        value
+                    ),
+                    parent=self,
+                )
+                return
+
+            mapping[field] = value
+            if field in self.required_fields:
+                used_columns.add(value)
+
+        missing = [field for field in self.required_fields if field not in mapping]
+        if missing:
+            messagebox.showerror(
+                "Налаштування імпорту",
+                "Не вказано всі обов'язкові поля: {}.".format(", ".join(missing)),
+                parent=self,
+            )
+            return
+
+        self.result = {
+            "column_mapping": mapping,
+            "save_template": bool(self.save_template_var.get()),
+        }
+        self.destroy()
 
 
 def run_app(*, data_dir: str | Path = ".price_compare_data", tags_config: str | Path | None = None) -> None:

--- a/price_compare/io.py
+++ b/price_compare/io.py
@@ -95,6 +95,10 @@ class PriceListImporter:
             for field, aliases in default_aliases.items()
         }
 
+        self.optional_fields = tuple(
+            sorted(field for field in self.column_aliases if field not in self.required_fields)
+        )
+
     def load(
         self,
         path: str | Path,
@@ -117,6 +121,189 @@ class PriceListImporter:
         price_list = PriceList(supplier=supplier_name, products=products)
         price_list.sort_products()
         return price_list
+
+    def detect_headers(self, path: str | Path) -> list[str]:
+        """Return a list of header names found in the supplied file."""
+
+        headers, rows = self.peek(path, limit=0)
+        if headers:
+            return headers
+        if rows:
+            # When rows are provided we can derive headers from the first row keys.
+            first_row = rows[0]
+            return list(first_row.keys())
+
+        path = Path(path)
+        suffix = path.suffix.lower()
+        if suffix == ".csv":
+            with path.open("r", encoding="utf-8-sig", newline="") as fp:
+                reader = csv.reader(fp)
+                try:
+                    headers = next(reader)
+                except StopIteration:
+                    return []
+            return [str(header).strip() for header in headers if str(header).strip()]
+
+        if suffix == ".json":
+            with path.open("r", encoding="utf-8") as fp:
+                payload = json.load(fp)
+            products_data = payload.get("products") if isinstance(payload, dict) else None
+            if not isinstance(products_data, list):
+                return []
+            headers: list[str] = []
+            for item in products_data:
+                if not isinstance(item, dict):
+                    continue
+                for key in item.keys():
+                    key_str = str(key)
+                    if key_str not in headers:
+                        headers.append(key_str)
+            return headers
+
+        if suffix == ".xlsx":
+            if load_workbook is None:
+                raise ValueError("Імпорт Excel недоступний. Встановіть залежність 'openpyxl'.")
+            workbook = load_workbook(path, data_only=True)
+            sheet = workbook.active
+            rows_iter = sheet.iter_rows(min_row=1, values_only=True)
+            try:
+                headers_row = next(rows_iter)
+            except StopIteration:
+                return []
+            headers = [
+                str(value).strip() if value is not None else ""
+                for value in headers_row
+            ]
+            return [header for header in headers if header]
+
+        return []
+
+    def peek(
+        self, path: str | Path, *, limit: int = 10
+    ) -> tuple[list[str], list[dict[str, str]]]:
+        """Return headers and a preview of rows from the provided file."""
+
+        path = Path(path)
+        suffix = path.suffix.lower()
+        headers: list[str] = []
+        rows: list[dict[str, str]] = []
+
+        if suffix == ".csv":
+            with path.open("r", encoding="utf-8-sig", newline="") as fp:
+                reader = csv.DictReader(fp)
+                headers = [
+                    str(header).strip()
+                    for header in (reader.fieldnames or [])
+                    if header is not None and str(header).strip()
+                ]
+                if limit == 0:
+                    return headers, rows
+                for index, row in enumerate(reader):
+                    if limit and index >= limit:
+                        break
+                    rows.append({header: str(row.get(header, "")) for header in headers})
+            return headers, rows
+
+        if suffix == ".json":
+            with path.open("r", encoding="utf-8") as fp:
+                payload = json.load(fp)
+
+            products_data = payload.get("products") if isinstance(payload, dict) else None
+            if isinstance(products_data, list):
+                for item in products_data:
+                    if not isinstance(item, dict):
+                        continue
+                    for key in item.keys():
+                        key_str = str(key)
+                        if key_str not in headers:
+                            headers.append(key_str)
+                if limit == 0:
+                    return headers, rows
+                for item in products_data[: limit or None]:
+                    if not isinstance(item, dict):
+                        continue
+                    rows.append({header: str(item.get(header, "")) for header in headers})
+            return headers, rows
+
+        if suffix == ".xlsx":
+            if load_workbook is None:
+                raise ValueError("Імпорт Excel недоступний. Встановіть залежність 'openpyxl'.")
+
+            workbook = load_workbook(path, data_only=True)
+            sheet = workbook.active
+            rows_iter = sheet.iter_rows(min_row=1, values_only=True)
+
+            try:
+                headers_row = next(rows_iter)
+            except StopIteration:
+                return headers, rows
+
+            headers = [
+                str(value).strip() if value is not None else ""
+                for value in headers_row
+            ]
+            headers = [header for header in headers if header]
+
+            if limit == 0:
+                return headers, rows
+
+            for index, values in enumerate(rows_iter):
+                if limit and index >= limit:
+                    break
+                row_dict = {}
+                for idx, header in enumerate(headers):
+                    if idx < len(values):
+                        value = values[idx]
+                    else:
+                        value = ""
+                    row_dict[header] = "" if value is None else str(value)
+                rows.append(row_dict)
+            return headers, rows
+
+        raise ValueError(f"Unsupported import format '{suffix}'.")
+
+    def suggest_mapping(
+        self,
+        headers: Sequence[str],
+        column_mapping: dict[str, str | Sequence[str]] | None = None,
+    ) -> dict[str, str]:
+        """Suggest column mapping for given headers without enforcing required fields."""
+
+        normalized_headers = {
+            str(header).strip().lower(): str(header)
+            for header in headers
+            if header is not None and str(header).strip()
+        }
+
+        resolved: dict[str, str] = {}
+
+        def iter_override(field: str) -> Iterable[str]:
+            if not column_mapping or field not in column_mapping:
+                return []
+            value = column_mapping[field]
+            if isinstance(value, str):
+                return [value]
+            return [str(candidate) for candidate in value]
+
+        for field, aliases in self.column_aliases.items():
+            override_candidates = [
+                str(candidate).strip().lower()
+                for candidate in iter_override(field)
+                if str(candidate).strip()
+            ]
+            candidates = override_candidates + [
+                alias for alias in aliases if alias not in override_candidates
+            ]
+
+            for candidate in candidates:
+                candidate_key = candidate.strip().lower()
+                if not candidate_key:
+                    continue
+                if candidate_key in normalized_headers:
+                    resolved[field] = normalized_headers[candidate_key]
+                    break
+
+        return resolved
 
     def _load_csv(
         self,

--- a/price_compare/templates.py
+++ b/price_compare/templates.py
@@ -1,0 +1,115 @@
+"""Import template storage utilities."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+
+@dataclass
+class ImportTemplate:
+    """Represents saved import settings for a supplier."""
+
+    supplier: str
+    column_mapping: Dict[str, str]
+    headers: List[str]
+
+
+class ImportTemplateStore:
+    """Persist import templates on disk for re-use."""
+
+    def __init__(self, data_dir: str | os.PathLike[str]) -> None:
+        self.data_dir = Path(data_dir)
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+        self.path = self.data_dir / "import_templates.json"
+
+    def _key(self, supplier: str) -> str:
+        return supplier.strip().lower()
+
+    def _load_all(self) -> Dict[str, dict]:
+        if not self.path.exists():
+            return {}
+        try:
+            with self.path.open("r", encoding="utf-8") as fp:
+                payload = json.load(fp)
+        except (OSError, json.JSONDecodeError):
+            return {}
+        if not isinstance(payload, dict):
+            return {}
+        templates = payload.get("templates", payload)
+        if not isinstance(templates, dict):
+            return {}
+        return templates
+
+    def _write_all(self, payload: Dict[str, dict]) -> None:
+        to_dump = {"templates": payload}
+        with self.path.open("w", encoding="utf-8") as fp:
+            json.dump(to_dump, fp, indent=2, ensure_ascii=False)
+
+    def list_templates(self) -> List[ImportTemplate]:
+        templates: List[ImportTemplate] = []
+        for key, value in self._load_all().items():
+            if not isinstance(value, dict):
+                continue
+            supplier = value.get("supplier") or key
+            column_mapping = value.get("column_mapping")
+            headers = value.get("headers") or []
+            if not isinstance(column_mapping, dict):
+                continue
+            templates.append(
+                ImportTemplate(
+                    supplier=str(supplier),
+                    column_mapping={
+                        str(field): str(column)
+                        for field, column in column_mapping.items()
+                        if str(column)
+                    },
+                    headers=[str(header) for header in headers if str(header)],
+                )
+            )
+        templates.sort(key=lambda template: template.supplier.lower())
+        return templates
+
+    def get_template(self, supplier: str) -> Optional[ImportTemplate]:
+        key = self._key(supplier)
+        raw = self._load_all().get(key)
+        if not isinstance(raw, dict):
+            return None
+        column_mapping = raw.get("column_mapping")
+        if not isinstance(column_mapping, dict):
+            return None
+        headers = raw.get("headers") or []
+        return ImportTemplate(
+            supplier=raw.get("supplier") or supplier,
+            column_mapping={
+                str(field): str(column)
+                for field, column in column_mapping.items()
+                if str(column)
+            },
+            headers=[str(header) for header in headers if str(header)],
+        )
+
+    def save_template(
+        self,
+        supplier: str,
+        column_mapping: Dict[str, str],
+        headers: Iterable[str],
+    ) -> None:
+        key = self._key(supplier)
+        payload = self._load_all()
+        payload[key] = {
+            "supplier": supplier,
+            "column_mapping": dict(column_mapping),
+            "headers": [str(header) for header in headers],
+        }
+        self._write_all(payload)
+
+    def delete_template(self, supplier: str) -> None:
+        key = self._key(supplier)
+        payload = self._load_all()
+        if key in payload:
+            payload.pop(key)
+            self._write_all(payload)


### PR DESCRIPTION
## Summary
- add a reusable import template store to persist supplier column mappings
- extend the importer with header preview helpers for the new import workflow
- introduce an import settings dialog that lets users map columns and reuse templates

## Testing
- `python -m compileall price_compare`

------
https://chatgpt.com/codex/tasks/task_e_68e63f62dab083258f54de905530774d